### PR TITLE
Use Hackage-friendly Stack settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -64,3 +64,5 @@ extra-package-dbs: []
 # 
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+pvp-bounds: both


### PR DESCRIPTION
Helps ensure that Hackage is able to build the docs for you package